### PR TITLE
refactor: add build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ __pycache__/
 *.pyc
 *.egg-info
 
+# build
+build/
+
 # node
 node_modules/
 


### PR DESCRIPTION
This pull request ensures the `build` directory is ignored by git.
