### PR TITLE
feat: depricate step done return value

### DIFF
--- a/examples/use_simzoo.py
+++ b/examples/use_simzoo.py
@@ -9,8 +9,8 @@ import simzoo  # noqa: F401
 # TODO: [ ] Check ex3_ekf.
 # TODO: [ ] Check cartpole.
 
-# ENV_NAME = "Oscillator-v1"
-ENV_NAME = "Ex3EKF-v1"
+ENV_NAME = "Oscillator-v1"
+# ENV_NAME = "Ex3EKF-v1"
 
 if __name__ == "__main__":
     env = gym.make(ENV_NAME, render_mode="human")

--- a/simzoo/envs/biological/oscillator/oscillator.py
+++ b/simzoo/envs/biological/oscillator/oscillator.py
@@ -199,7 +199,10 @@ class Oscillator(gym.Env, OscillatorDisturber):
 
                 - obs (:obj:`numpy.ndarray`): The current state
                 - cost (:obj:`numpy.float64`): The current cost.
-                - done (:obj:`bool`): Whether the episode was done.
+                - terminated (:obj:`bool`): Whether the episode was done.
+                - truncated (:obj:`bool`): Whether the episode was truncated. This value
+                    is set by wrappers when for example a time limit is reached or the
+                    agent goes out of bounds.
                 - info_dict (:obj:`dict`): Dictionary with additional information.
         """
         # Clip action if needed
@@ -299,16 +302,14 @@ class Oscillator(gym.Env, OscillatorDisturber):
         # cost = (abs(p1 - r1)) ** 0.2
 
         # Define stopping criteria
-        if cost > self.reward_range.high or cost < self.reward_range.low:
-            done = True
-        else:
-            done = False
+        terminated = bool(cost > self.reward_range.high or cost < self.reward_range.low)
 
         # Return state, cost, done and reference
         return (
             np.array([m1, m2, m3, p1, p2, p3, r1, p1 - r1]),
             cost,
-            done,
+            terminated,
+            False,
             dict(reference=r1, state_of_interest=p1 - r1),
         )
 

--- a/simzoo/envs/classic_control/ex3_ekf/ex3_ekf.py
+++ b/simzoo/envs/classic_control/ex3_ekf/ex3_ekf.py
@@ -185,7 +185,10 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
 
                 - obs (:obj:`numpy.ndarray`): The current state
                 - cost (:obj:`numpy.float64`): The current cost.
-                - done (:obj:`bool`): Whether the episode was done.
+                - terminated (:obj:`bool`): Whether the episode was done.
+                - truncated (:obj:`bool`): Whether the episode was truncated. This value
+                    is set by wrappers when for example a time limit is reached or the
+                    agent goes out of bounds.
                 - info_dict (:obj:`dict`): Dictionary with additional information.
         """
         # Clip action if needed
@@ -250,10 +253,7 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
         # cost = np.abs(hat_x_1 - x_1)**1 + np.abs(hat_x_2 - x_2)**1
 
         # Define stopping criteria
-        if cost > self.reward_range.high or cost < self.reward_range.low:
-            done = True
-        else:
-            done = False
+        terminated = bool(cost > self.reward_range.high or cost < self.reward_range.low)
 
         # Update state
         self.state = np.array([hat_x_1, hat_x_2, x_1, x_2])
@@ -264,7 +264,8 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
         return (
             np.array([hat_x_1, hat_x_2, x_1, x_2]),
             cost,
-            done,
+            terminated,
+            False,
             dict(
                 reference=y_1,
                 state_of_interest=np.array([hat_x_1 - x_1, hat_x_2 - x_2]),


### PR DESCRIPTION
This commit depricates the step `done` return value. This was done for consistency with gym v0.25.0
(see https://github.com/openai/gym/commit/907b1b20dd9ac0cba5803225059b9c6673702467).

BREAKING CHANGE: step now returns 5 values instead of 4.
