### PR TITLE
refactor: improve env init seed option

### DIFF
--- a/simzoo/envs/biological/oscillator/oscillator.py
+++ b/simzoo/envs/biological/oscillator/oscillator.py
@@ -7,7 +7,7 @@ import gymnasium as gym
 import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
-from gymnasium.utils import colorize, seeding
+from gymnasium.utils import colorize
 
 if __name__ == "__main__":
     from oscillator_disturber import OscillatorDisturber
@@ -98,7 +98,6 @@ class Oscillator(gym.Env, OscillatorDisturber):
     def __init__(
         self,
         render_mode=None,
-        seed=None,
         reference_type="periodic",
         clipped_action=True,
     ):
@@ -107,8 +106,6 @@ class Oscillator(gym.Env, OscillatorDisturber):
         Args:
             render_mode (str, optional): The render mode you want to use. Defaults to
                 ``None`` as it is not used in this environment.
-            seed (int, optional): A random seed for the environment. By default
-                ``None``.
             reference_type (str, optional): The type of reference you want to use
                 (``constant`` or ``periodic``), by default ``periodic``.
             clipped_action (str, optional): Whether the actions should be clipped if
@@ -179,21 +176,9 @@ class Oscillator(gym.Env, OscillatorDisturber):
             dtype=np.float32,
         )
 
-        # Create random seed and set gymnasium environment parameters
-        self.seed(seed)
         self.viewer = None
         self.state = None
         self.steps_beyond_done = None
-
-    def seed(self, seed=None):
-        """Return random seed.
-
-        Args:
-            seed (int, optional): A random seed for the environment. By default
-                ``None``.
-        """
-        self.np_random, seed = seeding.np_random(seed)
-        return [seed]
 
     def step(self, action):
         """Take step into the environment.
@@ -338,8 +323,7 @@ class Oscillator(gym.Env, OscillatorDisturber):
                 numpy.ndarray: Array containing the current observations.
                 dict: Dictionary containing additional information.
         """
-        if seed is not None:
-            self.seed(seed)
+        super().reset(seed=seed)
 
         # Return random initial state
         self.state = (

--- a/simzoo/envs/classic_control/cart_pole_cost/cart_pole_cost.py
+++ b/simzoo/envs/classic_control/cart_pole_cost/cart_pole_cost.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import logger, spaces
 from gymnasium.error import DependencyNotInstalled
-from gymnasium.utils import colorize, seeding
+from gymnasium.utils import colorize
 
 if __name__ == "__main__":
     from cart_pole_cost_disturber import CartPoleDisturber
@@ -108,7 +108,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
     def __init__(
         self,
         render_mode=None,
-        seed=None,
         task_type="stabilization",
         reference_type="constant",
         kinematics_integrator="euler",
@@ -118,8 +117,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
 
         Args:
             render_mode (str, optional): Gym rendering mode. By default ``None``.
-            seed (int, optional): A random seed for the environment. By default
-                ``None``.
             task_type (str, optional): The task you want the agent to perform (options
                 are "reference_tracking" and "stabilization"). Defaults to
                 "stabilization".
@@ -220,9 +217,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
             dtype=np.float32,
         )
 
-        # Create random seed and set gymnasium environment parameters
-        self.seed(seed)  # TODO: remove
-
         self.screen_width = 600
         self.screen_height = 400
         self.screen = None
@@ -231,11 +225,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         self.state = None
 
         self.steps_beyond_terminated = None
-
-    def seed(self, seed=None):
-        """Return random seed."""
-        self.np_random, seed = seeding.np_random(seed)
-        return [seed]
 
     def set_params(self, length, mass_of_cart, mass_of_pole, gravity):
         """Sets the most important system parameters.
@@ -458,8 +447,7 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
             numpy.ndarray: Array containing the current observations.
             info_dict (:obj:`dict`): Dictionary with additional information.
         """
-        if seed is not None:
-            self.seed(seed)
+        super().reset(seed=seed)
 
         # Return random initial state
         self.state = (

--- a/simzoo/envs/classic_control/ex3_ekf/ex3_ekf.py
+++ b/simzoo/envs/classic_control/ex3_ekf/ex3_ekf.py
@@ -25,7 +25,7 @@ import gymnasium as gym
 import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
-from gymnasium.utils import colorize, seeding
+from gymnasium.utils import colorize
 
 if __name__ == "__main__":
     from ex3_ekf_disturber import Ex3EKFDisturber
@@ -101,7 +101,6 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
     def __init__(
         self,
         render_mode=None,
-        seed=None,
         clipped_action=True,
     ):
         """Constructs all the necessary attributes for the Ex3EKF instance.
@@ -109,8 +108,6 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
         Args:
             render_mode (str, optional): The render mode you want to use. Defaults to
                 ``None`` as it is not used in this environment.
-            seed (int, optional): A random seed for the environment. By default
-                `None``.
             clipped_action (str, optional): Whether the actions should be clipped if
                 they are greater than the set action limit. Defaults to ``True``.
         """
@@ -164,22 +161,11 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
             dtype=np.float32,
         )
 
-        self.seed(seed)
         self._clipped_action = clipped_action
         self.viewer = None
         self.state = None
         self.output = None
         self.steps_beyond_done = None
-
-    def seed(self, seed=None):
-        """Return random seed.
-
-        Args:
-            seed (int, optional): A random seed for the environment. By default
-                `None``.
-        """
-        self.np_random, seed = seeding.np_random(seed)
-        return [seed]
 
     def step(self, action):
         """Take step into the environment.
@@ -292,8 +278,7 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
             numpy.ndarray: Array containing the current observations.
             info_dict (:obj:`dict`): Dictionary with additional information.
         """
-        if seed is not None:
-            self.seed(seed)
+        super().reset(seed=seed)
 
         x_1 = self.np_random.uniform(-np.pi / 2, np.pi / 2)
         x_2 = self.np_random.uniform(-np.pi / 2, np.pi / 2)


### PR DESCRIPTION
This commit removes the seeding argument in the environment initializer.
See
https://gymnasium.farama.org/content/migration-guide/#seed-and-random-number-generator
for more information.
