### PR TITLE
refactor: remove custom vectorization code and add example

### DIFF
--- a/examples/use_simzoo.py
+++ b/examples/use_simzoo.py
@@ -25,5 +25,6 @@ if __name__ == "__main__":
         observation, reward, terminated, truncated, info = env.step(action)
 
         if terminated or truncated:
+            print("Environment terminated or truncated. Resetting.")
             observation, info = env.reset()
     env.close()

--- a/examples/use_simzoo_vectorized.py
+++ b/examples/use_simzoo_vectorized.py
@@ -1,0 +1,43 @@
+"""A simple example on how to use the Simzoo environments in a vectorized manner.
+
+.. note::
+    For more information on vectorized environments, see the `gym.vector`_
+    documentation.
+
+.. _gym.vector: https://gymnasium.farama.org/api/vector/
+"""
+import gymnasium as gym
+
+import simzoo  # noqa: F401
+
+# ENV_NAME = "Oscillator-v1"
+# ENV_NAME = "Ex3EKF-v1"
+# ENV_NAME = "CartPoleCost-v1"
+ENV_NAME = "CartPole-v1"
+
+if __name__ == "__main__":
+    envs = gym.vector.make(
+        ENV_NAME, render_mode="human", num_envs=3, asynchronous=False
+    )
+
+    # Define a policy function.
+    # NOTE: Can be any function that takes an observation and returns an action.
+    def policy(*args, **kwargs):
+        """A simple policy that samples random actions."""
+        return envs.action_space.sample()
+
+    # Run training loop.
+    observation, info = envs.reset(seed=42)
+    for _ in range(1000):
+        action = policy(observation)  # User-defined policy function
+        observation, reward, terminated, truncated, info = envs.step(action)
+
+        done = terminated | truncated
+        if any(done):
+            # Get indexes of environments that are done.
+            done_idxs = [i for i, d in enumerate(done) if d]
+            print(
+                f"Environment(s) {done_idxs} terminated or truncated. These will be "
+                "automatically reset."
+            )  # NOTE: Reset is done automatically by the vectorized environment.
+    envs.close()

--- a/simzoo/envs/classic_control/cartpole_cost/cartpole_cost.py
+++ b/simzoo/envs/classic_control/cartpole_cost/cartpole_cost.py
@@ -34,6 +34,11 @@ RANDOM_STEP = True  # Use random action in __main__. Zero action otherwise.
 class CartPoleCost(gym.Env, CartPoleDisturber):
     """Custom cartPole gymnasium environment.
 
+    .. Note::
+        Can also be used in a vectorized manner. See the `gym.vector`_ documentation.
+
+    .. _gym.vector: https://gymnasium.farama.org/api/vector/
+
     Description:
         This environment was based on the cart-pole environment described by Barto,
         Sutton, and Anderson in
@@ -144,7 +149,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         "render_modes": ["human", "rgb_array"],
         "render_fps": 50,
     }  # Not used during training but in other gymnasium utilities.
-    instances = []
 
     def __init__(
         self,
@@ -246,14 +250,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         # }
         self.const_pos = 4.0  # Reference constraint.
         self.target_pos = 0.0  # Reference target.
-
-        # Add ability to use multiple instances of the environment.
-        self.__class__.instances.append(self)
-        self._instance_nr = len(self.__class__.instances)
-        logger.info(
-            f"CartPoleCost environment {self._instance_nr} is initiated for a "
-            f"{task_type}' task and '{reference_type}' reference."
-        )
 
     def set_params(self, length, mass_of_cart, mass_of_pole, gravity):
         """Sets the most important system parameters.
@@ -497,7 +493,9 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
 
         # Set random initial state and reset several env variables.
         self.state = (
-            self.np_random.uniform(low=low, high=high) if random else self._init_state
+            self.np_random.uniform(low=low, high=high, size=(4,))
+            if random
+            else self._init_state
         )
         self.steps_beyond_terminated = None
         self.t = 0.0


### PR DESCRIPTION
This commit removes the custom vectorization code since now
vectorization is handled by the [gymnasium](https://gymnasium.farama.org/api/vector/)
library.
